### PR TITLE
Mitigate coretime auto-renew benchmarked weights issues

### DIFF
--- a/system-parachains/coretime/coretime-kusama/src/coretime.rs
+++ b/system-parachains/coretime/coretime-kusama/src/coretime.rs
@@ -345,6 +345,6 @@ impl pallet_broker::Config for Runtime {
 	type PalletId = BrokerPalletId;
 	type AdminOrigin = EnsureRoot<AccountId>;
 	type SovereignAccountOf = SovereignAccountOf;
-	type MaxAutoRenewals = ConstU32<100>;
+	type MaxAutoRenewals = ConstU32<0>;
 	type PriceAdapter = pallet_broker::CenterTargetPrice<Balance>;
 }

--- a/system-parachains/coretime/coretime-kusama/src/lib.rs
+++ b/system-parachains/coretime/coretime-kusama/src/lib.rs
@@ -183,19 +183,27 @@ parameter_types! {
 	pub const SS58Prefix: u8 = 2;
 }
 
-/// Filter out credit purchase calls until the credit system is implemented. Otherwise, users
+/// Filter:
+/// - Credit purchase calls until the credit system is implemented. Otherwise, users
 /// may have chance of locking their funds forever on purchased credits they cannot use.
-pub struct IsBrokerCreditPurchaseCall;
-impl Contains<RuntimeCall> for IsBrokerCreditPurchaseCall {
+/// - Auto-renew functionality until resolution of polkadot-sdk issue
+/// [#6474](https://github.com/paritytech/polkadot-sdk/issues/6474)
+pub struct IsFilteredBrokerCall;
+impl Contains<RuntimeCall> for IsFilteredBrokerCall {
 	fn contains(c: &RuntimeCall) -> bool {
-		matches!(c, RuntimeCall::Broker(pallet_broker::Call::purchase_credit { .. }))
+		matches!(
+			c,
+			RuntimeCall::Broker(pallet_broker::Call::purchase_credit { .. }) |
+				RuntimeCall::Broker(pallet_broker::Call::enable_auto_renew { .. }) |
+				RuntimeCall::Broker(pallet_broker::Call::disable_auto_renew { .. })
+		)
 	}
 }
 
 // Configure FRAME pallets to include in runtime.
 #[derive_impl(frame_system::config_preludes::ParaChainDefaultConfig as frame_system::DefaultConfig)]
 impl frame_system::Config for Runtime {
-	type BaseCallFilter = EverythingBut<IsBrokerCreditPurchaseCall>;
+	type BaseCallFilter = EverythingBut<IsFilteredBrokerCall>;
 	/// The identifier used to distinguish between accounts.
 	type AccountId = AccountId;
 	/// The nonce type for storing how many extrinsics an account has signed.

--- a/system-parachains/coretime/coretime-polkadot/src/coretime.rs
+++ b/system-parachains/coretime/coretime-polkadot/src/coretime.rs
@@ -348,6 +348,6 @@ impl pallet_broker::Config for Runtime {
 	type PalletId = BrokerPalletId;
 	type AdminOrigin = EnsureRoot<AccountId>;
 	type SovereignAccountOf = SovereignAccountOf;
-	type MaxAutoRenewals = ConstU32<100>;
+	type MaxAutoRenewals = ConstU32<0>;
 	type PriceAdapter = pallet_broker::CenterTargetPrice<Balance>;
 }

--- a/system-parachains/coretime/coretime-polkadot/src/lib.rs
+++ b/system-parachains/coretime/coretime-polkadot/src/lib.rs
@@ -180,17 +180,21 @@ parameter_types! {
 	pub const SS58Prefix: u8 = 0;
 }
 
-/// Filter out credit purchase calls until the credit system is implemented.
-///
-/// Otherwise, users may have chance of locking their funds forever on purchased credits they cannot
-/// use. Also filter the interlace call until the relay can support this fully.
+/// Filter:
+/// - Credit purchase calls until the credit system is implemented. Otherwise, users
+/// may have chance of locking their funds forever on purchased credits they cannot use.
+/// - The interlace call until the relay can support this fully
+/// - Auto-renew functionality until resolution of polkadot-sdk issue
+/// [#6474](https://github.com/paritytech/polkadot-sdk/issues/6474)
 pub struct IsFilteredBrokerCall;
 impl Contains<RuntimeCall> for IsFilteredBrokerCall {
 	fn contains(c: &RuntimeCall) -> bool {
 		matches!(
 			c,
 			RuntimeCall::Broker(pallet_broker::Call::purchase_credit { .. }) |
-				RuntimeCall::Broker(pallet_broker::Call::interlace { .. })
+				RuntimeCall::Broker(pallet_broker::Call::interlace { .. }) |
+				RuntimeCall::Broker(pallet_broker::Call::enable_auto_renew { .. }) |
+				RuntimeCall::Broker(pallet_broker::Call::disable_auto_renew { .. })
 		)
 	}
 }


### PR DESCRIPTION
Auto-renew benchmarks are currently weightless due to some uncovered issues with the benchmarks reported in https://github.com/paritytech/polkadot-sdk/issues/6474

This can be easily mitigated for `(enable|disable)_auto_renew` by filtering the calls until the benchmarks have been fixed in https://github.com/paritytech/polkadot-sdk/pull/6505 (or another way) and backported. However, this also affects start_sales so setting the `MaxAutoRenewals` to 0 should negate its impact on the benchmark.

Ideally we'd wait for this backport, but this simple change can be a short term fix if there is pressure to get this merged before then.